### PR TITLE
Add peer and ccid envs

### DIFF
--- a/core/chaincode/container_runtime.go
+++ b/core/chaincode/container_runtime.go
@@ -52,6 +52,12 @@ func (c *ContainerRuntime) Start(ccci *ccprovider.ChaincodeContainerInfo, codePa
 		return err
 	}
 
+	// Inject the peer and version information.
+	// TODO put these into LaunchConfig at some point.
+	lc.Envs = append(lc.Envs, fmt.Sprintf("CORE_CHAINCODE_INFO_PEER_ADDR=%s", c.PeerAddress))
+	lc.Envs = append(lc.Envs, fmt.Sprintf("CORE_CHAINCODE_INFO_NAME=%s", ccci.Name))
+	lc.Envs = append(lc.Envs, fmt.Sprintf("CORE_CHAINCODE_INFO_VERSION=%s", ccci.Version))
+
 	chaincodeLogger.Debugf("start container: %s", cname)
 	chaincodeLogger.Debugf("start container with args: %s", strings.Join(lc.Args, " "))
 	chaincodeLogger.Debugf("start container with env:\n\t%s", strings.Join(lc.Envs, "\n\t"))

--- a/core/container/kubernetescontroller/kubernetescontroller.go
+++ b/core/container/kubernetescontroller/kubernetescontroller.go
@@ -156,7 +156,8 @@ func (api *KubernetesAPI) createChaincodePodDeployment(ccid ccintf.CCID, args []
 
 	envvars := []apiv1.EnvVar{}
 	for _, v := range env {
-		ss := strings.Split(v, "=")
+		// Use splitN(.., .., 2) here to handle base64 encoded strings coming in thru env.
+		ss := strings.SplitN(v, "=", 2)
 		kubernetesLogger.Debugf("create chaincode deployment: add env %s = %s", ss[0], ss[1])
 		envvars = append(envvars, apiv1.EnvVar{Name: ss[0], Value: ss[1]})
 	}


### PR DESCRIPTION
* Adding CORE_CHAINCODE_INFO_* fields to provide a coordinate of the executing chaincode.
* Fixed string split in kube env setup to allow handling of fields with '=' in the value portion.