### PR TITLE
remove extraneous check on dontkill

### DIFF
--- a/core/container/kubernetescontroller/kubernetescontroller.go
+++ b/core/container/kubernetescontroller/kubernetescontroller.go
@@ -185,11 +185,7 @@ func (api *KubernetesAPI) Start(ccid ccintf.CCID,
 func (api *KubernetesAPI) Stop(ccid ccintf.CCID, timeout uint, dontkill bool, dontremove bool) error {
 	kubernetesLogger.Infof("Stop chaincode %s requested. [kill=%t, remove=%t]", ccid.Name, !dontkill, !dontremove)
 	// Remove any existing deployments by matching labels
-	if !dontremove && !dontremove {
-		return api.stopAllInternal(ccid)
-	}
-
-	return nil
+	return api.stopAllInternal(ccid)
 }
 
 // Wait blocks until the container stops and returns the exit code of the container.


### PR DESCRIPTION
if stop is called ... we stop... we really don't care about the remove (doesn't apply to K8s as the image is in GCR) and don't kill isn't our responsibility, the K8s infrastructure manages the shutdown/term